### PR TITLE
feat(infra): HAB-002 single-container Docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+node_modules
+**/node_modules
+dist
+**/dist
+coverage
+**/coverage
+.DS_Store
+*.log
+*.sqlite
+api/data
+data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:22-bookworm-slim AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY api/package.json ./api/package.json
+COPY web/package.json ./web/package.json
+COPY packages/shared-types/package.json ./packages/shared-types/package.json
+
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM node:22-bookworm-slim AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=3000
+ENV CORS_ORIGIN=http://localhost:3000
+ENV SQLITE_PATH=/app/data/habitor.sqlite
+
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/api/dist ./api/dist
+COPY --from=build /app/api/package.json ./api/package.json
+COPY --from=build /app/web/dist/web/browser ./api/public/web
+
+EXPOSE 3000
+
+CMD ["node", "api/dist/main.js"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository uses npm workspaces with:
 - `npm run db:migrate --workspace api` to run SQLite migrations
 - `npm run db:revert --workspace api` to revert the latest SQLite migration
 - `npm run db:seed --workspace api` to apply starter core seed data
+- `docker compose up --build` to run API + scheduler + Angular static assets in one container
 
 ### Environment
 
@@ -28,3 +29,10 @@ API startup now validates required env vars and exits with explicit errors when 
 - `SQLITE_PATH` is required
 - `PORT` must be `1-65535`
 - `NODE_ENV` must be `development`, `test`, or `production`
+
+### Docker (HAB-002)
+
+- Run `docker compose up --build`
+- API health is available at `http://localhost:3000/`
+- Angular static assets are served by NestJS at `http://localhost:3000/app/`
+- SQLite persists across restarts in the mounted host path `./data` (container path `/app/data`)

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,7 +1,9 @@
 import { existsSync, mkdirSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { config as loadDotenv } from 'dotenv';
 import { NestFactory } from '@nestjs/core';
+import type { NestExpressApplication } from '@nestjs/platform-express';
+import type { Request, Response } from 'express';
 import { DataSource } from 'typeorm';
 import { AppModule } from './app.module';
 import { loadAppConfig } from './config/app-config';
@@ -12,7 +14,9 @@ async function bootstrap() {
   const config = loadAppConfig();
   ensureParentDirectory(config.sqlitePath);
 
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  configureStaticAssets(app, config.nodeEnv);
+
   const dataSource = app.get(DataSource);
   await dataSource.runMigrations();
   app.enableCors({ origin: config.corsOrigin });
@@ -43,4 +47,46 @@ function ensureParentDirectory(path: string) {
   const resolvedPath = resolve(path);
   const parentDirectory = dirname(resolvedPath);
   mkdirSync(parentDirectory, { recursive: true });
+}
+
+function configureStaticAssets(
+  app: NestExpressApplication,
+  nodeEnv: string,
+): void {
+  if (nodeEnv !== 'production') {
+    return;
+  }
+
+  const assetRoot = resolveStaticAssetRoot();
+  if (!assetRoot) {
+    console.warn(
+      'Production web assets were not found. Continuing without static hosting.',
+    );
+    return;
+  }
+
+  app.useStaticAssets(assetRoot, { prefix: '/app/' });
+  const expressApp = app.getHttpAdapter().getInstance() as {
+    get: (path: RegExp, handler: (req: Request, res: Response) => void) => void;
+  };
+
+  expressApp.get(/^\/app(\/.*)?$/, (_request: Request, response: Response) => {
+    response.sendFile(join(assetRoot, 'index.html'));
+  });
+}
+
+function resolveStaticAssetRoot(): string | null {
+  const candidates = [
+    resolve(process.cwd(), 'public/web'),
+    resolve(process.cwd(), '..', 'web', 'dist', 'web', 'browser'),
+    resolve(__dirname, '..', 'public', 'web'),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(join(candidate, 'index.html'))) {
+      return candidate;
+    }
+  }
+
+  return null;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  habitor:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: production
+      HOST: 0.0.0.0
+      PORT: 3000
+      CORS_ORIGIN: http://localhost:3000
+      SQLITE_PATH: /app/data/habitor.sqlite
+    volumes:
+      - ./data:/app/data


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that builds shared types, API, and Angular web assets in one image
- run a single NestJS container process that serves API/scheduler and Angular static files
- mount SQLite storage via docker-compose volume at ./data -> /app/data
- configure production static hosting in NestJS at /app/ while keeping health endpoint at /

## Validation
- docker compose config
- npm run lint --workspace api
- npm run test --workspace api

## Notes
- full docker build could not be executed in this environment because the Docker daemon is not running.

Closes #12